### PR TITLE
Refactored the `TypeMap` API

### DIFF
--- a/deps/std/testing.ts
+++ b/deps/std/testing.ts
@@ -1,4 +1,5 @@
 export {
   assert,
   assertEquals,
+  assertThrows,
 } from "https://deno.land/std@0.106.0/testing/asserts.ts";

--- a/lib/constants/lexicon.ts
+++ b/lib/constants/lexicon.ts
@@ -1,3 +1,12 @@
+export enum ReservedType {
+  Number = "number",
+  AsyncNumber = "async_number",
+  String = "string",
+  AsyncString = "async_string",
+  Boolean = "boolean",
+  AsyncBoolean = "async_boolean",
+}
+
 export enum Lexicon {
   Identifier,
   Nester,

--- a/lib/constants/lexicon.ts
+++ b/lib/constants/lexicon.ts
@@ -1,10 +1,7 @@
 export enum ReservedType {
   Number = "number",
-  AsyncNumber = "async_number",
   String = "string",
-  AsyncString = "async_string",
   Boolean = "boolean",
-  AsyncBoolean = "async_boolean",
 }
 
 export enum Lexicon {

--- a/lib/typemap/mod.ts
+++ b/lib/typemap/mod.ts
@@ -1,0 +1,1 @@
+export { ReservedType, TypeMap } from "./typemap.ts";

--- a/lib/typemap/typemap.test.ts
+++ b/lib/typemap/typemap.test.ts
@@ -1,5 +1,10 @@
-import { ReservedType, TypeMap } from "./typemap.ts";
-import { assert, assertThrows } from "../../deps/std/testing.ts";
+import { ModifierMode, ReservedType, TypeMap } from "./typemap.ts";
+import { assert, assertEquals, assertThrows } from "../../deps/std/testing.ts";
+
+const PREFIX = "async_";
+const SUFFIX = "_list";
+const MODIFY_ASYNC = (t: string) => `Promise<${t}>`;
+const MODIFY_LIST = (t: string) => `${t}[]`;
 
 Deno.test("Throws when instantiated with empty input", () => {
   assertThrows(() => new TypeMap(), Error);
@@ -22,4 +27,46 @@ Deno.test("Successfully instantiates typemap", () => {
   ]);
   const success = typemap.size === 3;
   assert(success);
+});
+
+Deno.test("Successfully instantiates typemap with a prefix modifier", () => {
+  const typemap = new TypeMap([
+    [ReservedType.Number, "number"],
+    [ReservedType.String, "string"],
+    [ReservedType.Boolean, "boolean"],
+  ]);
+  // "async_" => Promise<T>
+  typemap.addModifier(PREFIX, MODIFY_ASYNC);
+  assertEquals(typemap.get(PREFIX + ReservedType.Number), "Promise<number>");
+  assertEquals(typemap.get(PREFIX + ReservedType.String), "Promise<string>");
+  assertEquals(typemap.get(PREFIX + ReservedType.Boolean), "Promise<boolean>");
+});
+
+Deno.test("Successfully instantiates typemap with a suffix modifier", () => {
+  const typemap = new TypeMap([
+    [ReservedType.Number, "number"],
+    [ReservedType.String, "string"],
+    [ReservedType.Boolean, "boolean"],
+  ]);
+  // "_list" => T[] (aka Array<T>)
+  typemap.addModifier(SUFFIX, MODIFY_LIST, ModifierMode.Suffix);
+  assertEquals(typemap.get(ReservedType.Number + SUFFIX), "number[]");
+  assertEquals(typemap.get(ReservedType.String + SUFFIX), "string[]");
+  assertEquals(typemap.get(ReservedType.Boolean + SUFFIX), "boolean[]");
+});
+
+Deno.test("Successfully instantiates typemap with prefix and suffix modifiers", () => {
+  const typemap = new TypeMap([
+    [ReservedType.Number, "number"],
+    [ReservedType.String, "string"],
+    [ReservedType.Boolean, "boolean"],
+  ]);
+  typemap.addModifier(PREFIX, MODIFY_ASYNC);
+  typemap.addModifier(SUFFIX, MODIFY_LIST, ModifierMode.Suffix);
+  assertEquals(typemap.get(PREFIX + ReservedType.Number), "Promise<number>");
+  assertEquals(typemap.get(PREFIX + ReservedType.String), "Promise<string>");
+  assertEquals(typemap.get(PREFIX + ReservedType.Boolean), "Promise<boolean>");
+  assertEquals(typemap.get(ReservedType.Number + SUFFIX), "number[]");
+  assertEquals(typemap.get(ReservedType.String + SUFFIX), "string[]");
+  assertEquals(typemap.get(ReservedType.Boolean + SUFFIX), "boolean[]");
 });

--- a/lib/typemap/typemap.test.ts
+++ b/lib/typemap/typemap.test.ts
@@ -70,3 +70,36 @@ Deno.test("Successfully instantiates typemap with prefix and suffix modifiers", 
   assertEquals(typemap.get(ReservedType.String + SUFFIX), "string[]");
   assertEquals(typemap.get(ReservedType.Boolean + SUFFIX), "boolean[]");
 });
+
+Deno.test("Successfully removes modifier", () => {
+  const typemap = new TypeMap([
+    [ReservedType.Number, "number"],
+    [ReservedType.String, "string"],
+    [ReservedType.Boolean, "boolean"],
+  ]);
+  const modifierId = typemap.addModifier(PREFIX, MODIFY_ASYNC);
+  assertEquals(typemap.get(PREFIX + ReservedType.Number), "Promise<number>");
+  typemap.removeModifier(modifierId);
+  // No error is expected to be thrown when attempting to remove a
+  // nonexistant modifer.
+  typemap.removeModifier(1234567890);
+  assertEquals(typemap.get(PREFIX + ReservedType.Number), undefined);
+});
+
+Deno.test("Prefixed key is modified successfully", () => {
+  const actual = TypeMap.modifyKey(PREFIX + ReservedType.Number, {
+    alias: PREFIX,
+    modify: MODIFY_ASYNC,
+    mode: ModifierMode.Prefix,
+  });
+  assertEquals(actual, ReservedType.Number);
+});
+
+Deno.test("Suffixed key is modified successfully", () => {
+  const actual = TypeMap.modifyKey(ReservedType.Number + SUFFIX, {
+    alias: SUFFIX,
+    modify: MODIFY_LIST,
+    mode: ModifierMode.Suffix,
+  });
+  assertEquals(actual, ReservedType.Number);
+});

--- a/lib/typemap/typemap.test.ts
+++ b/lib/typemap/typemap.test.ts
@@ -1,0 +1,25 @@
+import { ReservedType, TypeMap } from "./typemap.ts";
+import { assert, assertThrows } from "../../deps/std/testing.ts";
+
+Deno.test("Throws when instantiated with empty input", () => {
+  assertThrows(() => new TypeMap(), Error);
+});
+
+Deno.test("Throws when missing one required type", () => {
+  assertThrows(() =>
+    new TypeMap([
+      // Skipping ReservedType.String
+      [ReservedType.Number, "float64"],
+      [ReservedType.Boolean, "bool"],
+    ]), Error);
+});
+
+Deno.test("Successfully instantiates typemap", () => {
+  const typemap = new TypeMap([
+    [ReservedType.Number, "float64"],
+    [ReservedType.String, "string"],
+    [ReservedType.Boolean, "bool"],
+  ]);
+  const success = typemap.size === 3;
+  assert(success);
+});

--- a/lib/typemap/typemap.ts
+++ b/lib/typemap/typemap.ts
@@ -1,13 +1,76 @@
 import { ReservedType } from "../constants/lexicon.ts";
 
+export enum ModifierMode {
+  Prefix,
+  Suffix,
+}
+
+export interface Modifier {
+  alias: string;
+  mode: ModifierMode;
+  modify: (t: string) => string;
+}
+
 export class TypeMap extends Map<string, string> {
-  constructor(input?: Array<[ReservedType | string, string]>) {
+  constructor(
+    input?: Array<[ReservedType | string, string]>,
+    private modifiers: Array<Modifier | undefined> = [],
+  ) {
     super(input);
     for (const reservedType of Object.values(ReservedType)) {
-      if (!reservedType.startsWith("async") && !this.has(reservedType)) {
+      if (!this.has(reservedType)) {
         throw new Error(`Expected required type ${reservedType} to be mapped`);
       }
     }
+  }
+
+  has(key: string): boolean {
+    return this.get(key) !== undefined;
+  }
+
+  get(key: string): string | undefined {
+    if (super.has(key)) return super.get(key);
+    for (const modifier of this.modifiers) {
+      if (modifier === undefined) continue;
+      const modifiedKey = TypeMap.modifyKey(key, modifier);
+      const mappedType = super.get(modifiedKey);
+      if (mappedType !== undefined) {
+        return modifier.modify(mappedType);
+      }
+    }
+    return undefined;
+  }
+
+  addModifier(
+    alias: string,
+    modify: (t: string) => string,
+    mode: ModifierMode = ModifierMode.Prefix,
+  ): number {
+    this.modifiers.push({ alias, mode, modify });
+    return this.modifiers.length - 1;
+  }
+
+  removeModifier(modifierId: number): boolean {
+    return delete this.modifiers[modifierId];
+  }
+
+  static modifyKey(key: string, modifier: Modifier): string {
+    switch (modifier.mode) {
+      case ModifierMode.Suffix: {
+        if (key.endsWith(modifier.alias)) {
+          return key.slice(0, key.length - modifier.alias.length);
+        }
+        break;
+      }
+      case ModifierMode.Prefix:
+      default: {
+        if (key.startsWith(modifier.alias)) {
+          return key.slice(modifier.alias.length);
+        }
+        break;
+      }
+    }
+    return key;
   }
 }
 

--- a/lib/typemap/typemap.ts
+++ b/lib/typemap/typemap.ts
@@ -50,8 +50,8 @@ export class TypeMap extends Map<string, string> {
     return this.modifiers.length - 1;
   }
 
-  removeModifier(modifierId: number): boolean {
-    return delete this.modifiers[modifierId];
+  removeModifier(modifierId: number) {
+    delete this.modifiers[modifierId];
   }
 
   static modifyKey(key: string, modifier: Modifier): string {

--- a/lib/typemap/typemap.ts
+++ b/lib/typemap/typemap.ts
@@ -1,0 +1,14 @@
+import { ReservedType } from "../constants/lexicon.ts";
+
+export class TypeMap extends Map<string, string> {
+  constructor(input?: Array<[ReservedType | string, string]>) {
+    super(input);
+    for (const reservedType of Object.values(ReservedType)) {
+      if (!reservedType.startsWith("async") && !this.has(reservedType)) {
+        throw new Error(`Expected required type ${reservedType} to be mapped`);
+      }
+    }
+  }
+}
+
+export { ReservedType };


### PR DESCRIPTION
- Extends native JavaScript `Map` API.
- Includes _modifiers_ which can be used by the application programmer to specify custom types based on exact text match as well as special rules (e.g. prefixes and suffixes).